### PR TITLE
Restore compatibility with Magento 2.2 in Composer requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,7 @@
         "forum": "https://github.com/ripenecommerce/magento2-postmark/issues"
     },
     "require": {
-        "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0",
-        "magento/framework": "^102"
+        "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
This extension is fully compatible with Magento v2.2. But in order to install it, I had to remove the Magento v2.3 requirement from the composer.json file.

I'm not sure if you want to remove the compatibility all together, or simply specify that it is compatible with magento/framework ^101.