### PR TITLE
Remove PHP 5.x Add PHP 7.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,7 @@
         "forum": "https://github.com/ripenecommerce/magento2-postmark/issues"
     },
     "require": {
-        "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0",
-        "magento/framework": "^102"
+        "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "ripenecommerce/magento2-postmark",
     "description": "Postmark for Magento 2",
     "type": "magento2-module",
-    "version": "2.1.2",
+    "version": "2.1.3",
     "authors": [
         {
             "name": "Szymon Wlodarski",
@@ -25,7 +25,7 @@
         "forum": "https://github.com/ripenecommerce/magento2-postmark/issues"
     },
     "require": {
-        "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0",
+        "php": "~7.1.3||~7.2.0||~7.3.0",
         "magento/framework": "^101.0.8|^102"
     },
     "autoload": {


### PR DESCRIPTION
This matches the current Magento 2.3 [composer requirements](https://github.com/magento/magento2/blob/2.3/composer.json#L14), by removing the end of life PHP versions.