### PR TITLE
Fix Magento 2.3.3+ Email Encoding Compatibility

### DIFF
--- a/Model/Transport.php
+++ b/Model/Transport.php
@@ -22,6 +22,7 @@
 namespace Ripen\Postmark\Model;
 
 use Zend\Mail\Message as ZendMessage;
+use Zend\Mail\Headers as ZendHeaders;
 
 class Transport extends \Magento\Framework\Mail\Transport implements \Magento\Framework\Mail\TransportInterface
 {
@@ -76,13 +77,15 @@ class Transport extends \Magento\Framework\Mail\Transport implements \Magento\Fr
         }
 
         try {
-            $message = $this->message->getRawMessage();
+            // Create a Zend\Mail\Message object to pass to Postmark
+            $headers = new ZendHeaders();
+            $headers->addHeaders($this->message->getHeaders());
 
-            if ($this->message->getBody()->getParts()[0]->getEncoding() === 'quoted-printable') {
-                $message = quoted_printable_decode($message);
-            }
+            $message = new ZendMessage();
+            $message->setHeaders($headers);
+            $message->setBody($this->message->getBody());
 
-            $this->transportPostmark->send(ZendMessage::fromString($message));
+            $this->transportPostmark->send($message);
         } catch (\Throwable $e) {
             throw new \Magento\Framework\Exception\MailException(new \Magento\Framework\Phrase($e->getMessage()), $e);
         }

--- a/Model/Transport.php
+++ b/Model/Transport.php
@@ -76,9 +76,13 @@ class Transport extends \Magento\Framework\Mail\Transport implements \Magento\Fr
         }
 
         try {
-            $this->transportPostmark->send(
-                ZendMessage::fromString($this->message->getRawMessage())
-            );
+            $message = $this->message->getRawMessage();
+
+            if ($this->message->getBody()->getParts()[0]->getEncoding() === 'quoted-printable') {
+                $message = quoted_printable_decode($message);
+            }
+
+            $this->transportPostmark->send(ZendMessage::fromString($message));
         } catch (\Throwable $e) {
             throw new \Magento\Framework\Exception\MailException(new \Magento\Framework\Phrase($e->getMessage()), $e);
         }


### PR DESCRIPTION
As of Magento 2.3, email messages are encoded with the "quoted-printable" encoding by default.

This module also encodes the messages with "quoted-printable" thereby double-encoding all outgoing messages.

See Also https://github.com/magento/magento2/pull/23649