### PR TITLE
Delegate encoding to Zend/Laminas

### DIFF
--- a/Model/Transport/Postmark.php
+++ b/Model/Transport/Postmark.php
@@ -188,7 +188,7 @@ class Postmark implements \Zend\Mail\Transport\TransportInterface
                 $address = $from->rewind()->getEmail();
             }
         }
- 
+
         if (empty($address)) throw new PostmarkTransportException('No from address specified');
 
         return empty($name) ? $address : "$name <$address>";
@@ -347,10 +347,11 @@ class Postmark implements \Zend\Mail\Transport\TransportInterface
         $parts = $message->getBody()->getParts();
         foreach ($parts as $part) {
             if ($part->getType() !== Mime::TYPE_TEXT && $part->getType() !== Mime::TYPE_HTML) {
+                $part->setEncoding(\Laminas\Mime\Mime::ENCODING_BASE64);
                 $attachments[] = [
                     'ContentType' => $part->getType(),
                     'Name' => $part->getFileName(),
-                    'Content' => base64_encode($part->getRawContent())
+                    'Content' => $part->getContent()
                 ];
             }
         }


### PR DESCRIPTION
See https://github.com/laminas/laminas-mime/blob/2.9.x/src/Mime.php#L303

I'm using Laminas because, I suppose, at some point the Zend classes will stop working (https://community.magento.com/t5/Magento-DevBlog/Migration-of-Zend-Framework-to-the-Laminas-Project/ba-p/443251)