### PR TITLE
PHP 7.4 & Magento 2.3.7-p1 Compatibity

### DIFF
--- a/Model/Transport.php
+++ b/Model/Transport.php
@@ -21,8 +21,8 @@
  */
 namespace Ripen\Postmark\Model;
 
-use Zend\Mail\Message as ZendMessage;
-use Zend\Mail\Headers as ZendHeaders;
+use Laminas\Mail\Message as LaminasMessage;
+use Laminas\Mail\Headers as LaminasHeaders;
 
 class Transport extends \Magento\Framework\Mail\Transport implements \Magento\Framework\Mail\TransportInterface
 {
@@ -77,11 +77,11 @@ class Transport extends \Magento\Framework\Mail\Transport implements \Magento\Fr
         }
 
         try {
-            // Create a Zend\Mail\Message object to pass to Postmark
-            $headers = new ZendHeaders();
+            // Create a Laminas\Mail\Message object to pass to Postmark
+            $headers = new LaminasHeaders();
             $headers->addHeaders($this->message->getHeaders());
 
-            $message = new ZendMessage();
+            $message = new LaminasMessage();
             $message->setHeaders($headers);
             $message->setBody($this->message->getBody());
 

--- a/Model/Transport/Exception.php
+++ b/Model/Transport/Exception.php
@@ -21,6 +21,6 @@
  */
 namespace Ripen\Postmark\Model\Transport;
 
-class Exception extends \Zend\Mail\Exception\RuntimeException
+class Exception extends \Laminas\Mail\Exception\RuntimeException
 {
 }

--- a/Model/Transport/Postmark.php
+++ b/Model/Transport/Postmark.php
@@ -23,9 +23,9 @@ namespace Ripen\Postmark\Model\Transport;
 
 use Psr\Log\LogLevel;
 use Ripen\Postmark\Model\Transport\Exception as PostmarkTransportException;
-use Zend\Mime\Mime;
+use Laminas\Mime\Mime;
 
-class Postmark implements \Zend\Mail\Transport\TransportInterface
+class Postmark implements \Laminas\Mail\Transport\TransportInterface
 {
     /**
      * Postmark API Uri
@@ -69,11 +69,11 @@ class Postmark implements \Zend\Mail\Transport\TransportInterface
      * Send request to Postmark service
      *
      * @link http://developer.postmarkapp.com/developer-build.html
-     * @param \Zend\Mail\Message $message
+     * @param \Laminas\Mail\Message $message
      * @return void
      * @throws \Ripen\Postmark\Model\Transport\Exception
      */
-    public function send(\Zend\Mail\Message $message)
+    public function send(\Laminas\Mail\Message $message)
     {
         $recipients = $this->getRecipients($message);
         $bodyVersions = $this->getBody($message);
@@ -91,7 +91,7 @@ class Postmark implements \Zend\Mail\Transport\TransportInterface
         $errorMessage = null;
         try {
             $response = $this->prepareHttpClient('/email')
-                ->setMethod(\Zend\Http\Request::METHOD_POST)
+                ->setMethod(\Laminas\Http\Request::METHOD_POST)
                 ->setRawBody(json_encode($data))
                 ->send();
             $this->parseResponse($response);
@@ -111,7 +111,7 @@ class Postmark implements \Zend\Mail\Transport\TransportInterface
      * Get a HTTP client instance
      *
      * @param string $path
-     * @return \Zend\Http\Client
+     * @return \Laminas\Http\Client
      */
     protected function prepareHttpClient($path)
     {
@@ -121,11 +121,11 @@ class Postmark implements \Zend\Mail\Transport\TransportInterface
     /**
      * Returns a HTTP client object
      *
-     * @return \Zend\Http\Client
+     * @return \Laminas\Http\Client
      */
     public function getHttpClient()
     {
-        $client = new \Zend\Http\Client();
+        $client = new \Laminas\Http\Client();
         $client->setHeaders([
             'Accept' => 'application/json',
             'X-Postmark-Server-Token' => $this->apiKey
@@ -137,11 +137,11 @@ class Postmark implements \Zend\Mail\Transport\TransportInterface
     /**
      * Parse response object and check for errors
      *
-     * @param \Zend\Http\Response $response
+     * @param \Laminas\Http\Response $response
      * @return array
      * @throws \Ripen\Postmark\Model\Transport\Exception
      */
-    protected function parseResponse(\Zend\Http\Response $response)
+    protected function parseResponse(\Laminas\Http\Response $response)
     {
         $result = json_decode($response->getBody(), true);
 
@@ -172,13 +172,13 @@ class Postmark implements \Zend\Mail\Transport\TransportInterface
     /**
      * Get mail From
      *
-     * @param \Zend\Mail\Message $message
+     * @param \Laminas\Mail\Message $message
      * @return string|null
      */
-    public function getFrom(\Zend\Mail\Message $message)
+    public function getFrom(\Laminas\Mail\Message $message)
     {
         $sender = $message->getSender();
-        if ($sender instanceof \Zend\Mail\Address\AddressInterface) {
+        if ($sender instanceof \Laminas\Mail\Address\AddressInterface) {
             $name = $sender->getName();
             $address = $sender->getEmail();
         } else {
@@ -188,7 +188,7 @@ class Postmark implements \Zend\Mail\Transport\TransportInterface
                 $address = $from->rewind()->getEmail();
             }
         }
- 
+
         if (empty($address)) throw new PostmarkTransportException('No from address specified');
 
         return empty($name) ? $address : "$name <$address>";
@@ -197,11 +197,11 @@ class Postmark implements \Zend\Mail\Transport\TransportInterface
     /**
      * Get mail recipients (To, Cc, and Bcc)
      *
-     * @param \Zend\Mail\Message $message
+     * @param \Laminas\Mail\Message $message
      * @return array
      * @throws \Ripen\Postmark\Model\Transport\Exception
      */
-    public function getRecipients(\Zend\Mail\Message $message)
+    public function getRecipients(\Laminas\Mail\Message $message)
     {
         $recipients = [
             'To' => $this->addressListToArray($message->getTo()),
@@ -229,10 +229,10 @@ class Postmark implements \Zend\Mail\Transport\TransportInterface
     /**
      * Convert address list to simple array
      *
-     * @param \Zend\Mail\AddressList $addressList
+     * @param \Laminas\Mail\AddressList $addressList
      * @return array
      */
-    protected function addressListToArray(\Zend\Mail\AddressList $addressList)
+    protected function addressListToArray(\Laminas\Mail\AddressList $addressList)
     {
         $addresses = [];
         foreach ($addressList as $address) {
@@ -244,10 +244,10 @@ class Postmark implements \Zend\Mail\Transport\TransportInterface
     /**
      * Get mail Reply To
      *
-     * @param \Zend\Mail\Message $message
+     * @param \Laminas\Mail\Message $message
      * @return string
      */
-    public function getReplyTo(\Zend\Mail\Message $message)
+    public function getReplyTo(\Laminas\Mail\Message $message)
     {
         $addresses = $message->getReplyTo();
 
@@ -262,12 +262,12 @@ class Postmark implements \Zend\Mail\Transport\TransportInterface
     /**
      * Get mail subject
      *
-     * @param \Zend\Mail\Message $message
+     * @param \Laminas\Mail\Message $message
      * @return string
      */
-    public function getSubject(\Zend\Mail\Message $message)
+    public function getSubject(\Laminas\Mail\Message $message)
     {
-        /** @var \Zend\Mail\Header\Subject $subjectHeader */
+        /** @var \Laminas\Mail\Header\Subject $subjectHeader */
         $subjectHeader = $message->getHeaders()->get('Subject');
 
         if (! $subjectHeader) {
@@ -278,11 +278,11 @@ class Postmark implements \Zend\Mail\Transport\TransportInterface
     }
 
     /**
-     * @param \Zend\Mail\Message $message
+     * @param \Laminas\Mail\Message $message
      * @return array
      * @throws \Ripen\Postmark\Model\Transport\Exception
      */
-    public function getBody(\Zend\Mail\Message $message)
+    public function getBody(\Laminas\Mail\Message $message)
     {
         $bodyVersions = [
             Mime::TYPE_HTML => '',
@@ -290,7 +290,7 @@ class Postmark implements \Zend\Mail\Transport\TransportInterface
         ];
 
         $body = $message->getBody();
-        if ($body instanceof \Zend\Mime\Message) {
+        if ($body instanceof \Laminas\Mime\Message) {
             $parts = $message->getBody()->getParts();
             foreach ($parts as $part) {
                 if ($part->getType() == Mime::TYPE_HTML || $part->getType() == Mime::TYPE_TEXT) {
@@ -298,7 +298,7 @@ class Postmark implements \Zend\Mail\Transport\TransportInterface
                 }
             }
         } else {
-            /** @var \Zend\Mail\Header\ContentType $contentTypeHeader */
+            /** @var \Laminas\Mail\Header\ContentType $contentTypeHeader */
             $contentTypeHeader = $message->getHeaders()->get('ContentType');
             $contentType = $contentTypeHeader ? $contentTypeHeader->getType() : Mime::TYPE_TEXT;
             $bodyVersions[$contentType] = (string) $body;
@@ -316,7 +316,7 @@ class Postmark implements \Zend\Mail\Transport\TransportInterface
      *
      * @return string
      */
-    public function getTags(\Zend\Mail\Message $message)
+    public function getTags(\Laminas\Mail\Message $message)
     {
         $headers = $message->getHeaders();
 
@@ -325,7 +325,7 @@ class Postmark implements \Zend\Mail\Transport\TransportInterface
         if (! is_array($tagsHeaders)) $tagsHeaders = [];
 
         $tags = [];
-        /** @var \Zend\Mail\Header\GenericHeader $tagsHeader */
+        /** @var \Laminas\Mail\Header\GenericHeader $tagsHeader */
         foreach ($tagsHeaders as $tagsHeader) {
             $tags[] = $tagsHeader->getFieldValue();
         }
@@ -335,13 +335,13 @@ class Postmark implements \Zend\Mail\Transport\TransportInterface
     /**
      * Get mail Attachments
      *
-     * @param \Zend\Mail\Message $message
+     * @param \Laminas\Mail\Message $message
      * @return array
      */
-    public function getAttachments(\Zend\Mail\Message $message)
+    public function getAttachments(\Laminas\Mail\Message $message)
     {
         $body = $message->getBody();
-        if (! $body instanceof \Zend\Mime\Message) return [];
+        if (! $body instanceof \Laminas\Mime\Message) return [];
 
         $attachments = [];
         $parts = $message->getBody()->getParts();

--- a/Test/Unit/Model/Transport/PostmarkTest.php
+++ b/Test/Unit/Model/Transport/PostmarkTest.php
@@ -24,7 +24,7 @@ namespace Ripen\Postmark\Test\Unit\Model\Transport;
 class PostmarkTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var \Zend_Http_Client_Adapter_Interface
+     * @var \Laminas_Http_Client_Adapter_Interface
      */
     protected $adapter;
 
@@ -40,7 +40,7 @@ class PostmarkTest extends \PHPUnit\Framework\TestCase
 
     public function setUp()
     {
-        $this->adapter = new \Zend_Http_Client_Adapter_Test();
+        $this->adapter = new \Laminas_Http_Client_Adapter_Test();
 
         $this->helper = $this->getMockBuilder(\Ripen\Postmark\Helper\Data::class)
             ->setMethods(['getApiKey'])
@@ -57,7 +57,7 @@ class PostmarkTest extends \PHPUnit\Framework\TestCase
 
     public function testSendMail()
     {
-        $mail = new \Zend_Mail;
+        $mail = new \Laminas_Mail;
 
         $this->adapter->setResponse(
             "HTTP/1.1 200 OK"        . "\r\n" .
@@ -74,12 +74,12 @@ class PostmarkTest extends \PHPUnit\Framework\TestCase
 
     public function testGetHttpClient()
     {
-        $this->assertInstanceOf('\Zend_Http_Client', $this->transport->getHttpClient());
+        $this->assertInstanceOf('\Laminas_Http_Client', $this->transport->getHttpClient());
     }
 
     public function testGetFrom()
     {
-        $mail = new \Zend_Mail;
+        $mail = new \Laminas_Mail;
 
         $this->transport->setMail($mail);
         $this->assertEmpty($this->transport->getFrom());
@@ -90,7 +90,7 @@ class PostmarkTest extends \PHPUnit\Framework\TestCase
 
     public function testGetTo()
     {
-        $mail = new \Zend_Mail;
+        $mail = new \Laminas_Mail;
 
         $this->transport->setMail($mail);
         $this->assertEmpty($this->transport->getTo());
@@ -104,7 +104,7 @@ class PostmarkTest extends \PHPUnit\Framework\TestCase
 
     public function testGetCc()
     {
-        $mail = new \Zend_Mail;
+        $mail = new \Laminas_Mail;
 
         $this->transport->setMail($mail);
         $this->assertEmpty($this->transport->getCc());
@@ -118,7 +118,7 @@ class PostmarkTest extends \PHPUnit\Framework\TestCase
 
     public function testGetBcc()
     {
-        $mail = new \Zend_Mail;
+        $mail = new \Laminas_Mail;
 
         $this->transport->setMail($mail);
         $this->assertEmpty($this->transport->getBcc());
@@ -132,7 +132,7 @@ class PostmarkTest extends \PHPUnit\Framework\TestCase
 
     public function testGetReplyTo()
     {
-        $mail = new \Zend_Mail;
+        $mail = new \Laminas_Mail;
 
         $this->transport->setMail($mail);
         $this->assertEmpty($this->transport->getReplyTo());
@@ -143,7 +143,7 @@ class PostmarkTest extends \PHPUnit\Framework\TestCase
 
     public function testGetSubject()
     {
-        $mail = new \Zend_Mail;
+        $mail = new \Laminas_Mail;
 
         $this->transport->setMail($mail);
         $this->assertEmpty($this->transport->getSubject());
@@ -154,7 +154,7 @@ class PostmarkTest extends \PHPUnit\Framework\TestCase
 
     public function testGetBodyHtml()
     {
-        $mail = new \Zend_Mail;
+        $mail = new \Laminas_Mail;
 
         $this->transport->setMail($mail);
         $this->assertEmpty($this->transport->getBodyHtml());
@@ -165,7 +165,7 @@ class PostmarkTest extends \PHPUnit\Framework\TestCase
 
     public function testGetBodyText()
     {
-        $mail = new \Zend_Mail;
+        $mail = new \Laminas_Mail;
 
         $this->transport->setMail($mail);
         $this->assertEmpty($this->transport->getBodyText());
@@ -176,7 +176,7 @@ class PostmarkTest extends \PHPUnit\Framework\TestCase
 
     public function testGetTags()
     {
-        $mail = new \Zend_Mail;
+        $mail = new \Laminas_Mail;
 
         $this->transport->setMail($mail);
         $this->assertEmpty($this->transport->getTags());
@@ -190,15 +190,15 @@ class PostmarkTest extends \PHPUnit\Framework\TestCase
 
     public function testGetAttachements()
     {
-        $mail = new \Zend_Mail;
+        $mail = new \Laminas_Mail;
 
         $this->transport->setMail($mail);
         $this->assertEmpty($this->transport->getAttachments());
 
         $at = $mail->createAttachment('test');
         $at->type        = 'image/gif';
-        $at->disposition = \Zend_Mime::DISPOSITION_INLINE;
-        $at->encoding    = \Zend_Mime::ENCODING_BASE64;
+        $at->disposition = \Laminas_Mime::DISPOSITION_INLINE;
+        $at->encoding    = \Laminas_Mime::ENCODING_BASE64;
         $at->filename    = 'test.gif';
         $this->transport->setMail($mail);
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "ripenecommerce/magento2-postmark",
     "description": "Postmark for Magento 2",
     "type": "magento2-module",
-    "version": "2.1.5",
+    "version": "2.1.5-patch1",
     "authors": [
         {
             "name": "Szymon Wlodarski",
@@ -25,8 +25,8 @@
         "forum": "https://github.com/ripenecommerce/magento2-postmark/issues"
     },
     "require": {
-        "php": "~7.1.3||~7.2.0||~7.3.0",
-        "magento/framework": "^102.0.3"
+        "php": ">=7.1.3 ~7.4",
+        "magento/framework": "^102.0.3||^103.0.1"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
The current version is incompatible with Magento 2.3.7 as Zend has been renamed to Laminas.

This fix should also work with Magento 2.4 but I haven't tested it on that version yet, as we're still on the 2.3 branch.

> "Fatal Error: 'Cannot declare class Zend_Http_Client, because the name is already in use' in '[...]\/vendor\/magento\/zendframework1\/library\/Zend\/Http\/Client.php' on line 72"

EDIT: If you merge this, you'll want to change the version number to an official release, not my temporary `-patch1` suffix used internally.